### PR TITLE
Remove tivoli-client container after exit

### DIFF
--- a/tivoli-client/run-tivoli-client
+++ b/tivoli-client/run-tivoli-client
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd $(dirname $0)
-docker-compose run tivoli-client "$@" 2> >(grep -v '^Creating tivoli-client_tivoli-client_run')
+docker-compose run --rm tivoli-client "$@" 2> >(grep -v '^Creating tivoli-client_tivoli-client_run')


### PR DESCRIPTION
This removes the Tivoli Client container after it exits. Otherwise, we always have an old container sitting around for every backup run executed.
Or is there a good reason why we keep all the old containers?