### PR TITLE
Add an overview page for all running instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ python3 Praktomat/src/manage-local.py createsuperuser
 
 The application is accessible on https://PRAKTOMAT_DOMAIN/COMPOSE_PROJECT_NAME.
 
+## Overview page
+
+An overview page for all running instances is available on
+https://PRAKTOMAT_DOMAIN/.
+
+To generate the overview page for all the instances running,
+run `traefik/overview-page/generate.py` on the host system and supply all the
+paths to the env files that shall be included. The Python package libPyshell
+needs to be installed for the script to work.
+
 ## Operations
 
 Here are some notes on operating praktomat.

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -11,6 +11,20 @@ services:
       - $PWD/traefik_dynamic.toml:/traefik_dynamic.toml
       - $PWD/cert.pem:/cert.pem
       - $PWD/key.pem:/key.pem
+  overview-page:
+    image: kimchi
+    build:
+      context: ./kimchi
+      dockerfile: Dockerfile
+    networks:
+      - praktomat
+    volumes:
+      - $PWD/overview-page/output:/page
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.overview-page.rule=PathPrefix(`/`)
+      - traefik.http.routers.overview-page.entrypoints=websecure
+      - traefik.http.routers.overview-page.tls=true
 networks:
   praktomat:
     external: true

--- a/traefik/kimchi/Dockerfile
+++ b/traefik/kimchi/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.22-alpine as builder
+
+RUN apk add --update --no-cache --force-overwrite git make 
+WORKDIR /
+RUN git clone https://git.sr.ht/~emersion/kimchi \
+    && cd kimchi \
+    && git checkout 4b663f91b4bc7bb1a7d8257a436ef4c552f7875b
+
+WORKDIR /kimchi
+RUN make kimchi
+
+FROM alpine:3
+
+COPY --from=builder /kimchi/kimchi /usr/bin/kimchi
+COPY kimchi.conf /kimchi.conf
+
+USER nobody
+WORKDIR /
+EXPOSE 443
+ENTRYPOINT ["/usr/bin/kimchi", "-config", "/kimchi.conf"]

--- a/traefik/kimchi/kimchi.conf
+++ b/traefik/kimchi/kimchi.conf
@@ -1,0 +1,3 @@
+site http+insecure://:443 {
+    file_server /page
+}

--- a/traefik/overview-page/generate.py
+++ b/traefik/overview-page/generate.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+import os
+from shell import *
+import sys
+
+instances_html = []
+
+# Read instance template
+with open(pjoin(dirname(__file__), "instance.html.in")) as f:
+    instance_template = f.read()
+
+for path in sys.argv[1:]:
+    domain = "localhost"
+    name = "unknown instance name"
+    instance_id = ""
+    with open(path) as f:
+        for line in f.readlines():
+            if "PRAKTOMAT_NAME" in line:
+                name = line.replace("PRAKTOMAT_NAME=", "").strip()
+            elif "COMPOSE_PROJECT_NAME" in line:
+                instance_id = line.replace("COMPOSE_PROJECT_NAME=", "").strip()
+            elif "PRAKTOMAT_DOMAIN" in line:
+                domain = line.replace("PRAKTOMAT_DOMAIN=", "").strip()
+    fragment = instance_template.replace("<!-- NAME -->", name).replace("<!-- ID -->", instance_id).replace("<!-- DOMAIN -->", domain)
+    instances_html.append(fragment)
+
+# Read master template
+with open(pjoin(dirname(__file__), "index.html.in")) as f:
+    site = f.read()
+site = site.replace("<!-- INSTANCES -->", "\n".join(instances_html))
+with open(pjoin(dirname(__file__), "output", "index.html"), "w") as f:
+    f.write(site)

--- a/traefik/overview-page/index.html.in
+++ b/traefik/overview-page/index.html.in
@@ -1,0 +1,27 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+body {
+    padding: 20px;
+    font-family: sans-serif;
+}
+
+.instance-box {
+    background-color: ddd;
+    margin: .5rem;
+    padding: .5rem;
+}
+        </style>
+        <title>Available Praktomat instances</title>
+    </head>
+    <body>
+        <header>
+            <h1>Available Praktomat instances</h1>
+        </header>
+        <main>
+            <!-- INSTANCES -->
+        </main>
+    </body>
+</html>

--- a/traefik/overview-page/instance.html.in
+++ b/traefik/overview-page/instance.html.in
@@ -1,0 +1,5 @@
+<div class="instance-box">
+    <!-- NAME -->
+    <hr>
+    <a href="<!-- DOMAIN -->/<!-- ID -->>">https://<!-- DOMAIN -->/<!-- ID --></a>
+</div>

--- a/traefik/overview-page/output/.gitignore
+++ b/traefik/overview-page/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/up.sh
+++ b/up.sh
@@ -8,9 +8,18 @@ docker network create praktomat
 #docker build -t praktomat .
 #popd
 
-docker-compose --env-file=aud-ai.env up -d
-docker-compose --env-file=aud-win.env up -d
-docker-compose --env-file=prog2-aki.env up -d
+ENV_FILES=""
+start_instance() {
+    docker-compose --env-file=$1 up -d
+    ENV_FILES="$ENV_FILES $1"
+}
+
+start_instance aud-ai.env
+start_instance aud-win.env
+start_instance prog2-aki.env
+
+# Regenerate overview page
+python3 traefik/overview-page/generate.py $ENV_FILES
 
 cd traefik
 docker-compose up -d


### PR DESCRIPTION
This adds an overview page for all instances running. I chose [kimchi](https://git.sr.ht/~emersion/kimchi) as the HTTP server as it's super simple and pretty lightweight. The overview page can be generated by running `traefik/overview-page/generate.py` and supplying the paths to the env files that are currently in use. For our convenience, I adjusted the `up.sh` script to make it less likely that we forget to update the page.

I'm not sure if we're going to win a design award with the page. But that shouldn't matter... ;)

Closes #7