### PR TITLE
Delete default ubuntu user

### DIFF
--- a/praktomat/Dockerfile
+++ b/praktomat/Dockerfile
@@ -59,7 +59,13 @@ RUN apt-get update && apt-get install -yq \
   && rm -rf /var/lib/apt/lists/*
 
 # Add users
-RUN useradd -m praktomat && adduser praktomat sudo
+# The praktomat user has UID 1000 explicitly.
+# This allows an easier access to the files in work-data when the host user has
+# UID 1000 as well. Otherwise, files written inside the container will have the
+# praktomat user's UID. If that is not 1000, this UID leaks to the host system
+# and tin he default case (single user with UID 1000), the host user can't fully
+# access the files without using tools like sudo.
+RUN useradd -m praktomat -u 1000 && adduser praktomat sudo
 RUN useradd -m tester && adduser tester sudo && adduser tester praktomat
 COPY sudoers /etc/sudoers
 RUN chmod 440 /etc/sudoers

--- a/praktomat/Dockerfile
+++ b/praktomat/Dockerfile
@@ -2,6 +2,10 @@
 FROM ubuntu:noble
 EXPOSE 443/tcp
 
+# Remove default ubuntu user
+# We'll add our own Praktomat user instead
+RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
+
 # Setup timezone
 # Installing tzdata in the next step is required too
 ENV TZ=Europe/Berlin


### PR DESCRIPTION
With the Ubuntu 24.04 update, the Ubuntu image contains a standard non-root user called `ubuntu` with UID 1000. Our praktomat user has UID 1001 under these circumstances. With that change, the owner of the files in our work-data directories has UID 1001 and the user of the host system (given that he has UID 1000) might have trouble accessing them.

For convenience, I suggest to delete the ubuntu user. That way, our praktomat user will get UID 1000 again (just as it used to be) and the permission issues are gone.

Alternative solutions:
- We could also change the setup to use the ubuntu user instead. This would require changes all over the repository and I'm not sure if it's worth it.
- We could leave it as it is and live with occasionally prefixing our commands with `sudo` (when having to have a look at something inside of the work-data directory).