### PR TITLE
Fix file access when umlaut is contained in name

### DIFF
--- a/praktomat/Dockerfile
+++ b/praktomat/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:noble
+FROM ubuntu:questing
 EXPOSE 443/tcp
 
 # Remove default ubuntu user

--- a/praktomat/local.py
+++ b/praktomat/local.py
@@ -157,7 +157,7 @@ DOCKER_DISCARD_ARTEFACTS = True
 
 # Does Apache use "mod_xsendfile" version 1.0?
 # If you use "libapache2-mod-xsendfile", this flag needs to be set to False
-MOD_XSENDFILE_V1_0 = False
+MOD_XSENDFILE_V1_0 = True
 
 # Our VM has 4 cores, so lets try to use them
 # But Gradle has a common build directory for a project


### PR DESCRIPTION
Ubuntu 25.10 as well as the upcoming Ubuntu 26.04 LTS have the updated version of the xsendfile plugin for Apache. Praktomat already supports the new version, we just need to update the according flag in the config. Most importantly, this fixes the issue where uploaded files cannot be served if they contain an umlaut.