### PR TITLE
Do not modify Praktomat repository during build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - type: bind
         source: $HOME/praktomat/work-data/$COMPOSE_PROJECT_NAME
         target: /home/praktomat/work-data
+      # - type: bind
+      #   source: $HOME/devel/Praktomat
+      #   target: /home/praktomat/Praktomat
     depends_on:
       - postgresql
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - type: bind
         source: $HOME/praktomat/work-data/$COMPOSE_PROJECT_NAME
         target: /home/praktomat/work-data
+      # Uncomment the following block to use your local Praktomat repository instead of the one included in the image (useful during development)
+      # You then do not need to rebuild the image on each change or edit the container while it's running.
+      # Make sure to adjust the source path so it points to the Praktomat repository on your computer.
       # - type: bind
       #   source: $HOME/devel/Praktomat
       #   target: /home/praktomat/Praktomat

--- a/praktomat/Dockerfile
+++ b/praktomat/Dockerfile
@@ -98,7 +98,8 @@ ADD https://github.com/jplag/jplag/releases/download/v2.12.1-SNAPSHOT/jplag-2.12
 RUN sudo chown -R praktomat:praktomat /opt/praktomat-addons
 
 # Copy config file
-COPY local.py Praktomat/src/settings/local.py
+COPY local.py praktomat_docker_settings/docker_settings.py
+ENV DJANGO_SETTINGS_MODULE=docker_settings
 
 # Setup required directories
 RUN mkdir debug-data work-data test-data
@@ -108,9 +109,9 @@ ENV APACHE_RUN_USER=www-data
 ENV APACHE_RUN_GROUP=www-data
 RUN sudo adduser www-data praktomat
 RUN sudo a2enmod macro
-COPY praktomat.wsgi Praktomat/wsgi/praktomat.wsgi
-COPY apache_praktomat_wsgi.conf Praktomat/documentation/apache_praktomat_wsgi.conf
-RUN printf "\nInclude /home/praktomat/Praktomat/documentation/apache_praktomat_wsgi.conf\n" | sudo tee -a /etc/apache2/apache2.conf
+COPY praktomat.wsgi praktomat.wsgi
+COPY apache_praktomat_wsgi.conf apache_praktomat_wsgi.conf
+RUN printf "\nInclude /home/praktomat/apache_praktomat_wsgi.conf\n" | sudo tee -a /etc/apache2/apache2.conf
 COPY mpm_event.conf /etc/apache2/mods-available/mpm_event.conf
 
 # Configure OpenLDAP
@@ -118,7 +119,7 @@ COPY CA17.pem /etc/ssl/certs/CA17.pem
 RUN printf "\nTLS_CACERT    /etc/ssl/certs/CA17.pem\n" | sudo tee -a /etc/ldap/ldap.conf
 
 # Initialize Praktomat
-RUN COMPOSE_PROJECT_NAME="" PRAKTOMAT_NAME="" PRAKTOMAT_ADMIN="" PRAKTOMAT_CHECKER_IMAGE="" PRAKTOMAT_CHECKER_UID_MOD="" PRAKTOMAT_CHECKER_WRITABLE="" PRAKTOMAT_DOMAIN="" python3 Praktomat/src/manage-local.py collectstatic --noinput --link
+RUN COMPOSE_PROJECT_NAME="" PRAKTOMAT_NAME="" PRAKTOMAT_ADMIN="" PRAKTOMAT_CHECKER_IMAGE="" PRAKTOMAT_CHECKER_UID_MOD="" PRAKTOMAT_CHECKER_WRITABLE="" PRAKTOMAT_DOMAIN="" PYTHONPATH=$HOME/praktomat_docker_settings python3 Praktomat/src/manage-local.py collectstatic --noinput --link
 
 # Configure Cron to automatically run all checkers
 COPY daily-cron.sh daily-cron.sh

--- a/praktomat/apache_praktomat_wsgi.conf
+++ b/praktomat/apache_praktomat_wsgi.conf
@@ -30,12 +30,17 @@ WSGIRestrictEmbedded On
     # > This will likely work for most users but might cause hard to track down issues or subtle bugs. A common user of the rare sub-interpreter feature is wsgi which also
     # > allows single-interpreter mode.
 
-    WSGIScriptAlias /$id  $path/Praktomat/wsgi/praktomat.wsgi process-group=local_$id application-group=%{GLOBAL}
+    WSGIScriptAlias /$id  $path/praktomat.wsgi process-group=local_$id application-group=%{GLOBAL}
 
 
     # The installation directory
     <Directory $path/Praktomat/>
         Require all granted
+    </Directory>
+    <Directory $path>
+        <Files praktomat.wsgi>
+            Require all granted
+        </Files>
     </Directory>
 
     # Depending on the version of apache(?), the following might be necessary

--- a/praktomat/local.py
+++ b/praktomat/local.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 from os import environ
 from os.path import join, dirname
 
-PRAKTOMAT_PATH = dirname(dirname(dirname(__file__)))
+PRAKTOMAT_PATH = join(dirname(dirname(__file__)), 'Praktomat')
 
 PRAKTOMAT_ID = environ['COMPOSE_PROJECT_NAME']
 
@@ -192,5 +192,5 @@ MIMETYPE_ADDITIONAL_EXTENSIONS = \
 TEST_MAXFILESIZE=1000000000
 
 # Finally load defaults for missing settings.
-from . import defaults
+from settings import defaults
 defaults.load_defaults(globals())

--- a/praktomat/praktomat.wsgi
+++ b/praktomat/praktomat.wsgi
@@ -34,7 +34,8 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings.%s' % (settings_module
 
 import sys
 
-sys.path.append(join(dirname(dirname(__file__)), "src"))
+sys.path.append("/home/praktomat/Praktomat/src")
+sys.path.append("/home/praktomat/praktomat_docker_settings")
 
 import warnings
 from django.core.cache import CacheKeyWarning

--- a/praktomat/run.sh
+++ b/praktomat/run.sh
@@ -10,5 +10,5 @@ env | egrep "^(PRAKTOMAT|COMPOSE_PROJECT_NAME|PATH)" > praktomat.env
 sudo cron
 
 # Apply migrations and run Praktomat
-python3 Praktomat/src/manage-local.py migrate --noinput && \
+PYTHONPATH=$HOME/praktomat_docker_settings python3 Praktomat/src/manage-local.py migrate --noinput && \
 sudo -E apache2ctl -DFOREGROUND


### PR DESCRIPTION
This allows us to bind mount the Praktomat repository for development without changing the regular Praktomat repository.